### PR TITLE
Fix remove phrase incorrect behavior [issue #192]

### DIFF
--- a/src/view/ChewingEditor.cpp
+++ b/src/view/ChewingEditor.cpp
@@ -193,6 +193,8 @@ void ChewingEditor::showAbout()
 
 void ChewingEditor::showDeleteConfirmWindow()
 {
+    if(!ui_.get()->userphraseView->selectionModel()->selectedIndexes().size()) return;
+    
     QString text = tr("Do you want to delete this phrase?");
 
     QMessageBox deleteBox(this);


### PR DESCRIPTION
Checking the selection phrases instead of only checking if there is no phrase.
I squashed my commit, PR #200.

